### PR TITLE
feat: add global exceptions and error codes

### DIFF
--- a/carrot/src/main/kotlin/waffle/team6/global/common/exception/CarrotControllerAdvice.kt
+++ b/carrot/src/main/kotlin/waffle/team6/global/common/exception/CarrotControllerAdvice.kt
@@ -1,0 +1,28 @@
+package waffle.team6.global.common.exception
+
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class CarrotControllerAdvice() {
+    private val logger = LoggerFactory.getLogger(this.javaClass.name)
+    @ExceptionHandler(value = [DataNotFoundException::class])
+    fun notfound(e: CarrotException) =
+        ResponseEntity(ErrorResponse(e.errorType.code, e.errorType.name, e.detail), HttpStatus.NOT_FOUND)
+
+    @ExceptionHandler(value = [InvalidRequestException::class])
+    fun badRequest(e: CarrotException) =
+        ResponseEntity(ErrorResponse(e.errorType.code, e.errorType.name, e.detail), HttpStatus.BAD_REQUEST)
+
+    @ExceptionHandler(value = [NotAllowedException::class])
+    fun notAllowed(e: CarrotException) =
+        ResponseEntity(ErrorResponse(e.errorType.code, e.errorType.name, e.detail), HttpStatus.FORBIDDEN)
+
+    @ExceptionHandler(value = [ConflictException::class])
+    fun conflict(e: CarrotException) =
+        ResponseEntity(ErrorResponse(e.errorType.code, e.errorType.name, e.detail), HttpStatus.CONFLICT)
+
+}

--- a/carrot/src/main/kotlin/waffle/team6/global/common/exception/CarrotException.kt
+++ b/carrot/src/main/kotlin/waffle/team6/global/common/exception/CarrotException.kt
@@ -1,0 +1,10 @@
+package waffle.team6.global.common.exception
+
+import java.lang.RuntimeException
+
+abstract class CarrotException(val errorType: ErrorType, val detail: String = "") : RuntimeException(errorType.name)
+
+abstract class InvalidRequestException(errorType: ErrorType, detail: String = "") : CarrotException(errorType, detail)
+abstract class DataNotFoundException(errorType: ErrorType, detail: String = "") : CarrotException(errorType, detail)
+abstract class NotAllowedException(errorType: ErrorType, detail: String = "") : CarrotException(errorType, detail)
+abstract class ConflictException(errorType: ErrorType, detail: String = "") : CarrotException(errorType, detail)

--- a/carrot/src/main/kotlin/waffle/team6/global/common/exception/ErrorResponse.kt
+++ b/carrot/src/main/kotlin/waffle/team6/global/common/exception/ErrorResponse.kt
@@ -1,0 +1,11 @@
+package waffle.team6.global.common.exception
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class ErrorResponse (
+    @JsonProperty("error_code")
+    val errorCode: Int,
+    @JsonProperty("error_message")
+    val errorMessage: String = "",
+    val detail: String = ""
+)

--- a/carrot/src/main/kotlin/waffle/team6/global/common/exception/ErrorType.kt
+++ b/carrot/src/main/kotlin/waffle/team6/global/common/exception/ErrorType.kt
@@ -1,0 +1,34 @@
+package waffle.team6.global.common.exception
+
+enum class ErrorType (
+    val code: Int
+    ) {
+    INVALID_REQUEST(0),
+    // error codes for BAD REQUEST
+    USER_INVALID_REQUEST(100),
+
+    PRODUCT_INVALID_REQUEST(200),
+
+
+    NOT_ALLOWED(3000),
+    // error codes for FORBIDDEN
+    USER_NOT_ALLOWED(3100),
+
+    PRODUCT_NOT_ALLOWED(3200),
+
+
+    DATA_NOT_FOUND(4000),
+    // error codes for NOT FOUND
+    USER_NOT_FOUND(4100),
+
+    PRODUCT_NOT_FOUND(4200),
+
+
+    CONFLICT(9000),
+    // error codes for CONFLICT
+    USER_CONFLICT(9100),
+
+    PRODUCT_CONFLICT(9200),
+
+    SERVER_ERROR(10000)
+}


### PR DESCRIPTION
기본적으로 세미나에서 사용했던 구조로 구현했고, 
에러코드는 API 별로 백의 자리로 나누었습니다.
필요할 때 마다 하위항목으로 추가하면 될 것 같습니다.