### PR TITLE
feat: add ImageController.kt for uploading/downloading images

### DIFF
--- a/carrot/src/main/kotlin/waffle/team6/carrot/image/ImageController.kt
+++ b/carrot/src/main/kotlin/waffle/team6/carrot/image/ImageController.kt
@@ -1,0 +1,45 @@
+package waffle.team6.carrot.image
+
+import org.springframework.core.io.InputStreamResource
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
+import java.io.File
+import java.nio.file.Files
+import java.time.LocalDateTime
+import kotlin.io.path.Path
+
+@RestController
+@RequestMapping("/api/v1/images")
+class ImageController {
+    @PostMapping("/")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun upload(@RequestPart files: List<MultipartFile>): ResponseEntity<List<String>> {
+        val images: MutableList<String> = mutableListOf()
+        for (file in files) {
+            val name: String? = file.originalFilename
+            if (name != null) {
+                val pathName = "/tmp/${LocalDateTime.now()}$name"
+                val path  = File(pathName)
+                file.transferTo(path)
+                images.add(pathName)
+            }
+        }
+        return ResponseEntity.status(HttpStatus.CREATED).body(images)
+    }
+
+    @GetMapping("/")
+    @ResponseStatus(HttpStatus.OK)
+    fun download(@RequestParam(required = true) path: String): ResponseEntity<InputStreamResource> {
+        return try {
+            val contentType = Files.probeContentType(Path(path))
+            val resource = InputStreamResource(Files.newInputStream(Path(path)))
+            ResponseEntity.status(HttpStatus.OK).header(HttpHeaders.CONTENT_TYPE, contentType).body(resource)
+        } catch (e: java.nio.file.NoSuchFileException) {
+            throw ImageNotFoundException()
+        }
+    }
+
+}

--- a/carrot/src/main/kotlin/waffle/team6/carrot/image/ImageNotFoundException.kt
+++ b/carrot/src/main/kotlin/waffle/team6/carrot/image/ImageNotFoundException.kt
@@ -1,0 +1,7 @@
+package waffle.team6.carrot.image
+
+import waffle.team6.global.common.exception.DataNotFoundException
+import waffle.team6.global.common.exception.ErrorType
+
+class ImageNotFoundException(detail: String = ""):
+        DataNotFoundException(ErrorType.IMAGE_NOT_FOUND, detail)

--- a/carrot/src/main/kotlin/waffle/team6/global/common/exception/ErrorType.kt
+++ b/carrot/src/main/kotlin/waffle/team6/global/common/exception/ErrorType.kt
@@ -23,6 +23,8 @@ enum class ErrorType (
 
     PRODUCT_NOT_FOUND(4200),
 
+    IMAGE_NOT_FOUND(4300),
+
 
     CONFLICT(9000),
     // error codes for CONFLICT

--- a/carrot/src/main/resources/application.yml
+++ b/carrot/src/main/resources/application.yml
@@ -21,6 +21,13 @@ spring:
       hibernate:
         ddl-auto: create
 
+  servlet:
+    multipart:
+      file-size-threshold: 3MB
+      location: /tmp
+      max-file-size: 100MB
+      max-request-size: 100MB
+
 ---
 
 spring:
@@ -39,3 +46,10 @@ spring:
       generate-ddl: true
       hibernate:
         ddl-auto: update
+
+  servlet:
+    multipart:
+      file-size-threshold: 3MB
+      location: /home/ec2-user/images
+      max-file-size: 100MB
+      max-request-size: 100MB


### PR DESCRIPTION
판매글 올릴 때나 유저 생성할 때 이미지 업로드/다운로드를 위한 컨트롤러입니다.
동작확인 완료했고 아주 아주 간단한 에러 핸들링만 해놓은 상태입니다.
이미지 다운로드 받을 때, 업로드 했을 때 반환된 String 값을 그대로 파라미터 `path`로 넣어주시면 됩니다.

approve 주시면 바로 머지할게요!