### PR TITLE
판매글 검색 API 수정

### DIFF
--- a/carrot/src/main/kotlin/waffle/team6/DataLoader.kt
+++ b/carrot/src/main/kotlin/waffle/team6/DataLoader.kt
@@ -5,7 +5,11 @@ import org.springframework.boot.ApplicationRunner
 import org.springframework.core.io.ClassPathResource
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import waffle.team6.carrot.image.repository.ImageRepository
+import waffle.team6.carrot.product.model.Category
+import waffle.team6.carrot.product.model.CategoryOfInterest
+import waffle.team6.carrot.product.repository.CategoryOfInterestRepository
 import waffle.team6.carrot.product.repository.LikeRepository
 import waffle.team6.carrot.product.repository.ProductRepository
 import waffle.team6.carrot.product.repository.PurchaseRequestRepository
@@ -20,19 +24,28 @@ class DataLoader(
   private val productRepository: ProductRepository,
   private val purchaseRequestRepository: PurchaseRequestRepository,
   private val likeRepository: LikeRepository,
+  private val categoryOfInterestRepository: CategoryOfInterestRepository,
   private val imageRepository: ImageRepository,
   private val passwordEncoder: PasswordEncoder
 ): ApplicationRunner {
+    @Transactional
     override fun run(args: ApplicationArguments?) {
         BufferedReader(InputStreamReader(ClassPathResource("data/example_user.csv").inputStream)).use { br ->
             br.lines().forEach {
                 val rawUser = it.split(" ")
-                userRepository.save(User(
+                val user = userRepository.save(User(
                     name = rawUser[0],
                     password = passwordEncoder.encode(rawUser[1]),
                     email = rawUser[2],
                     phone = rawUser[3],
+                    location = rawUser[4],
+                    rangeOfLocation = rawUser[5].toInt()
                 ))
+                for (i in 1..17) {
+                    user.categoriesOfInterest.add(
+                        categoryOfInterestRepository.save(CategoryOfInterest(user, Category.from(i)))
+                    )
+                }
             }
         }
 

--- a/carrot/src/main/kotlin/waffle/team6/carrot/product/dto/ProductDto.kt
+++ b/carrot/src/main/kotlin/waffle/team6/carrot/product/dto/ProductDto.kt
@@ -3,11 +3,13 @@ package waffle.team6.carrot.product.dto
 import jdk.jfr.BooleanFlag
 import org.hibernate.validator.constraints.Length
 import org.hibernate.validator.constraints.Range
+import org.springframework.validation.annotation.Validated
 import waffle.team6.carrot.product.model.Category
 import waffle.team6.carrot.product.model.Product
 import waffle.team6.carrot.product.model.Status
 import waffle.team6.carrot.user.dto.UserDto
 import java.time.LocalDateTime
+import javax.validation.Valid
 import javax.validation.constraints.*
 
 class ProductDto {
@@ -90,22 +92,32 @@ class ProductDto {
         @field:Range(min = 1, max = 17)
         val category: Int,
         @field:NotBlank
-        val location: String
+        val location: String,
+        @field:Range(min = 0, max = 3)
+        val rangeOfLocation: Int
     )
 
     data class ProductUpdateRequest(
         val images: List<Long>? = null,
+        @field:NotBlank
         val title: String? = null,
+        @field:Length(min = 1, max = 300)
         val content: String? = null,
+        @field:PositiveOrZero
         val price: Long? = null,
+        @field:BooleanFlag
         val negotiable: Boolean? = null,
+        @field:Range(min = 1, max = 17)
         val category: Int? = null,
+        @field:Range(min = 0, max = 3)
+        val rangeOfLocation: Int
     )
 
     data class ProductSearchRequest(
         val pageNumber: Int,
+        val pageSize: Int,
         val title: String,
-        val categories: List<Int>,
+        val categories: List<Category>? = null,
         val minPrice: Long? = null,
         val maxPrice: Long? = null
     )

--- a/carrot/src/main/kotlin/waffle/team6/carrot/product/exception/InvalidCategoryValueException.kt
+++ b/carrot/src/main/kotlin/waffle/team6/carrot/product/exception/InvalidCategoryValueException.kt
@@ -4,4 +4,4 @@ import waffle.team6.global.common.exception.ErrorType
 import waffle.team6.global.common.exception.InvalidRequestException
 
 class InvalidCategoryValueException(detail: String = ""):
-        InvalidRequestException(ErrorType.INVALID_CATEGORY_NUMBER, detail)
+        InvalidRequestException(ErrorType.INVALID_CATEGORY_VALUE, detail)

--- a/carrot/src/main/kotlin/waffle/team6/carrot/product/exception/InvalidPageNumberException.kt
+++ b/carrot/src/main/kotlin/waffle/team6/carrot/product/exception/InvalidPageNumberException.kt
@@ -1,7 +1,0 @@
-package waffle.team6.carrot.product.exception
-
-import waffle.team6.global.common.exception.ErrorType
-import waffle.team6.global.common.exception.InvalidRequestException
-
-class InvalidPageNumberException(detail: String = ""):
-        InvalidRequestException(ErrorType.INVALID_PAGE_NUMBER, detail)

--- a/carrot/src/main/kotlin/waffle/team6/carrot/product/model/Category.kt
+++ b/carrot/src/main/kotlin/waffle/team6/carrot/product/model/Category.kt
@@ -24,6 +24,12 @@ enum class Category(
     I_AM_BUYING(17);
 
     companion object {
-        fun from (findValue: Int): Category = Category.values().first { it.value == findValue }
+        fun from (findValue: Int): Category {
+            return try {
+                values().first { it.value == findValue }
+            } catch (e: NoSuchElementException) {
+                throw InvalidCategoryValueException()
+            }
+        }
     }
 }

--- a/carrot/src/main/kotlin/waffle/team6/carrot/product/model/CategoryOfInterest.kt
+++ b/carrot/src/main/kotlin/waffle/team6/carrot/product/model/CategoryOfInterest.kt
@@ -12,5 +12,6 @@ class CategoryOfInterest (
     @JoinColumn(name = "user", referencedColumnName = "id")
     val user: User,
 
+    @Enumerated(EnumType.STRING)
     val category: Category,
 ) :BaseTimeEntity()

--- a/carrot/src/main/kotlin/waffle/team6/carrot/product/model/Product.kt
+++ b/carrot/src/main/kotlin/waffle/team6/carrot/product/model/Product.kt
@@ -2,6 +2,7 @@ package waffle.team6.carrot.product.model
 
 import jdk.jfr.BooleanFlag
 import org.hibernate.validator.constraints.Length
+import org.hibernate.validator.constraints.Range
 import waffle.team6.carrot.BaseTimeEntity
 import waffle.team6.carrot.product.dto.ProductDto
 import waffle.team6.carrot.user.model.User
@@ -16,7 +17,7 @@ class Product (
     @JoinColumn(name = "user", referencedColumnName = "id")
     val user: User,
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.LAZY)
     var images: List<Long> = listOf(),
 
     @field:NotBlank
@@ -36,6 +37,9 @@ class Product (
 
     @field:NotBlank
     val location: String,
+
+    @field:Range(min = 0, max = 3)
+    var rangeOfLocation: Int,
 
     @field:PositiveOrZero
     var hit: Long,
@@ -65,6 +69,7 @@ class Product (
         negotiable = productPostRequest.negotiable?: true,
         category = Category.from(productPostRequest.category),
         location = productPostRequest.location,
+        rangeOfLocation = productPostRequest.rangeOfLocation,
         hit = 1,
         likes = 0,
         chats = 0,

--- a/carrot/src/main/kotlin/waffle/team6/carrot/product/model/Status.kt
+++ b/carrot/src/main/kotlin/waffle/team6/carrot/product/model/Status.kt
@@ -1,5 +1,5 @@
 package waffle.team6.carrot.product.model
 
 enum class Status{
-    FOR_SALE, RESERVED, SOLD_OUT
+    FOR_SALE, RESERVED, SOLD_OUT, HIDDEN
 }

--- a/carrot/src/main/kotlin/waffle/team6/carrot/product/repository/CategoryOfInterestRepository.kt
+++ b/carrot/src/main/kotlin/waffle/team6/carrot/product/repository/CategoryOfInterestRepository.kt
@@ -1,0 +1,7 @@
+package waffle.team6.carrot.product.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import waffle.team6.carrot.product.model.CategoryOfInterest
+
+interface CategoryOfInterestRepository: JpaRepository<CategoryOfInterest, Long?> {
+}

--- a/carrot/src/main/kotlin/waffle/team6/carrot/product/repository/ProductRepository.kt
+++ b/carrot/src/main/kotlin/waffle/team6/carrot/product/repository/ProductRepository.kt
@@ -5,26 +5,35 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import waffle.team6.carrot.product.model.Category
 import waffle.team6.carrot.product.model.Product
+import waffle.team6.carrot.product.model.Status
 
 interface ProductRepository: JpaRepository<Product, Long?> {
-    fun findAllByCategoryInAndLocationIn(
-        pageable: Pageable, categories: List<Category>, locations: List<String>
-    ): Page<Product>
-
-    fun findAllByCategoryInAndLocationInAndTitleContaining(
-        pageable: Pageable, categories: List<Category>, locations: List<String>, title: String
-    ): Page<Product>
-
-    fun findAllByCategoryInAndLocationInAndTitleContainingAndPriceIsGreaterThanEqual(
-        pageable: Pageable, categories: List<Category>, locations: List<String>, title: String, minPrice: Long
-    ): Page<Product>
-
-    fun findAllByCategoryInAndLocationInAndTitleContainingAndPriceIsLessThanEqual(
-        pageable: Pageable, categories: List<Category>, locations: List<String>, title: String, maxPrice: Long
-    ): Page<Product>
-
-    fun findAllByCategoryInAndLocationInAndTitleContainingAndPriceIsBetween(
+    fun findAllByCategoryInAndLocationInAndStatusIs(
         pageable: Pageable, categories: List<Category>, locations: List<String>,
-        title: String, minPrice: Long, maxPrice: Long
+        status: Status
+    ): Page<Product>
+
+    fun findAllByCategoryInAndLocationInAndTitleContainingAndStatusIs(
+        pageable: Pageable, categories: List<Category>, locations: List<String>,
+        title: String, status: Status
+    ): Page<Product>
+
+    fun findAllByCategoryInAndLocationInAndTitleContainingAndPriceIsGreaterThanEqualAndStatusIs(
+        pageable: Pageable, categories: List<Category>, locations: List<String>,
+        title: String, minPrice: Long, status: Status
+    ): Page<Product>
+
+    fun findAllByCategoryInAndLocationInAndTitleContainingAndPriceIsLessThanEqualAndStatusIs(
+        pageable: Pageable, categories: List<Category>, locations: List<String>,
+        title: String, maxPrice: Long, status: Status
+    ): Page<Product>
+
+    fun findAllByCategoryInAndLocationInAndTitleContainingAndPriceIsBetweenAndStatusIs(
+        pageable: Pageable, categories: List<Category>, locations: List<String>,
+        title: String, minPrice: Long, maxPrice: Long, status: Status
+    ): Page<Product>
+
+    fun findAllByUserId(
+        pageable: Pageable, userId: Long
     ): Page<Product>
 }

--- a/carrot/src/main/kotlin/waffle/team6/carrot/product/service/ProductService.kt
+++ b/carrot/src/main/kotlin/waffle/team6/carrot/product/service/ProductService.kt
@@ -140,8 +140,8 @@ class ProductService (
         if (product.user.id == user.id) throw ProductLikeBySellerException()
         if (product.status == Status.SOLD_OUT) throw ProductAlreadySoldOutException()
 
-        if (!user.likes.any { it.product == product}) {
-            val like = Like(user, product)
+        if (!user.likes.any { it.product.id == product.id}) {
+            val like = likeRepository.save(Like(user, product))
             product.likes += 1
             user.likes.add(like)
         }
@@ -151,7 +151,7 @@ class ProductService (
     fun cancelLikeProduct(user: User, id: Long) {
         val product = productRepository.findByIdOrNull(id) ?: throw ProductNotFoundException()
 
-        val like = user.likes.find { it.product == product }
+        val like = user.likes.find { it.product.id == product.id }
         if (like != null) {
             product.likes -= 1
             user.likes.remove(like)

--- a/carrot/src/main/kotlin/waffle/team6/global/common/exception/CarrotControllerAdvice.kt
+++ b/carrot/src/main/kotlin/waffle/team6/global/common/exception/CarrotControllerAdvice.kt
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import javax.validation.ConstraintViolationException
 
 @RestControllerAdvice
 class CarrotControllerAdvice() {
@@ -33,4 +34,8 @@ class CarrotControllerAdvice() {
     @ExceptionHandler(value = [AmazonServiceException::class])
     fun s3Error(e: AmazonServiceException) =
         ResponseEntity(ErrorResponse(e.errorCode.toInt(), e.errorType.toString(), e.errorMessage), HttpStatus.INTERNAL_SERVER_ERROR)
+
+    @ExceptionHandler(value = [ConstraintViolationException::class])
+    fun invalidRequestParameter(e: ConstraintViolationException) =
+        ResponseEntity(ErrorResponse(0, "INVALID_REQUEST_PARAMETER", e.message ?: ""), HttpStatus.BAD_REQUEST)
 }

--- a/carrot/src/main/kotlin/waffle/team6/global/common/exception/ErrorType.kt
+++ b/carrot/src/main/kotlin/waffle/team6/global/common/exception/ErrorType.kt
@@ -5,8 +5,7 @@ enum class ErrorType (
     ) {
     INVALID_REQUEST(0),
     // error codes for BAD REQUEST
-    INVALID_PAGE_NUMBER(1),
-    INVALID_CATEGORY_NUMBER(2),
+    INVALID_CATEGORY_VALUE(1),
 
     USER_INVALID_REQUEST(100),
     USER_INVALID_PASSWORD(101),

--- a/carrot/src/main/kotlin/waffle/team6/global/config/OpenEntityManagerConfig.kt
+++ b/carrot/src/main/kotlin/waffle/team6/global/config/OpenEntityManagerConfig.kt
@@ -1,0 +1,17 @@
+package waffle.team6.global.config
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.orm.jpa.support.OpenEntityManagerInViewFilter
+
+@Configuration
+class OpenEntityManagerConfig {
+    @Bean
+    fun openEntityManagerInViewFilter(): FilterRegistrationBean<OpenEntityManagerInViewFilter> {
+        val filterFilterRegistrationBean = FilterRegistrationBean<OpenEntityManagerInViewFilter>()
+        filterFilterRegistrationBean.filter = OpenEntityManagerInViewFilter()
+        filterFilterRegistrationBean.order = Int.MIN_VALUE
+        return filterFilterRegistrationBean
+    }
+}

--- a/carrot/src/main/kotlin/waffle/team6/global/config/OpenEntityManagerConfig.kt
+++ b/carrot/src/main/kotlin/waffle/team6/global/config/OpenEntityManagerConfig.kt
@@ -9,9 +9,9 @@ import org.springframework.orm.jpa.support.OpenEntityManagerInViewFilter
 class OpenEntityManagerConfig {
     @Bean
     fun openEntityManagerInViewFilter(): FilterRegistrationBean<OpenEntityManagerInViewFilter> {
-        val filterFilterRegistrationBean = FilterRegistrationBean<OpenEntityManagerInViewFilter>()
-        filterFilterRegistrationBean.filter = OpenEntityManagerInViewFilter()
-        filterFilterRegistrationBean.order = Int.MIN_VALUE
-        return filterFilterRegistrationBean
+        val openEntityManagerFilterRegistrationBean = FilterRegistrationBean<OpenEntityManagerInViewFilter>()
+        openEntityManagerFilterRegistrationBean.filter = OpenEntityManagerInViewFilter()
+        openEntityManagerFilterRegistrationBean.order = Int.MIN_VALUE
+        return openEntityManagerFilterRegistrationBean
     }
 }

--- a/carrot/src/main/resources/data/example_user.csv
+++ b/carrot/src/main/resources/data/example_user.csv
@@ -1,3 +1,3 @@
-Alice alicePassword alice@carrot.com 010-1234-5678
-Bob bobPassword bob@carrot.com 010-8765-4321
-Carol carolPassword carol@carrot.com 010-9999-9999
+Alice alicePassword alice@carrot.com 010-1234-5678 301 0
+Bob bobPassword bob@carrot.com 010-8765-4321 301 0
+Carol carolPassword carol@carrot.com 010-9999-9999 301 0


### PR DESCRIPTION
# 변경된 사항

1. 판매글 조회할 때 Request Parameter 관련
 - pageSize parameter 추가
 - categories required false로 수정 (기본 검색일 경우)
 - validation 추가 및 추가 handler 작성 (request parameter의 경우 validation 진행하면 스프링에서 error response가 아닌 exception이 떠서 500이 뜨게 되는데, 이를 방지하기 위해서 CarrotControllerAdvice에 추가했습니다.)
2. Product Repository
 - userService 쪽에서 user가 등록한 판매글을 findAllByUserId 함수를 통해 조회할 수 있습니다. (페이징 되어 있습니다)
3. CategoryOfInterest Repository 추가
4. Product - Image N+1 Problem 관련
 - ~~따로 테이블 생성하지 않고 FetchType.LAZY로 변경하니 한방 쿼리로 날라가는 거 확인했습니다.~~ 다시 확인해보니 아니네요. 테이블 만들겠습니다
5. enum class Category Exception 추가
 - 스프링에서 리스트로 들어오는 경우 validation이 복잡하게 되기 때문에 그냥 Category 클래스 안에 exception을 만들었습니다.
6. 더미데이터 관련 업데이트
7. OpenEntityManager.Config 관련
 - Spring security에서 `@Current User`로 던져주는 User 객체의 경우 영속성이 지속되지 않아서 productService에서 user쪽 필드에 product나 purchaseRequest를 추가/삭제 할때 Exception이 뜨게 됩니다. 자세한 이유는 https://tecoble.techcourse.co.kr/post/2020-09-20-entity-lifecycle-2/ 참고하시면 될 것 같습니다.


# 미구현 된 사항 (다음 PR)

1. 판매글 조회할 때 Request Parameter 관련
 - productStatus, rangeOfLocation 추가 예정
2. 판매글 숨김 API
3. Restful한 API 이름 변경
4. 판매글 조회/검색할 때 시간순 정렬
